### PR TITLE
RD-2066: Add offline planner

### DIFF
--- a/MapTilerSDK/build.gradle.kts
+++ b/MapTilerSDK/build.gradle.kts
@@ -106,6 +106,7 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.2.1")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.8.1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
 }
 
 // Generate a javadoc jar from Dokka HTML output (required by Maven Central)

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTDownloadTask.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTDownloadTask.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import java.io.File
+
+/**
+ * A protocol representing an asset to be downloaded.
+ */
+internal interface MTDownloadTask {
+    /**
+     * The unique identifier for the task (usually the source URL).
+     */
+    val id: String
+
+    /**
+     * The destination file where the resource will be saved.
+     */
+    val destinationFile: File?
+
+    /**
+     * Executes the download task.
+     */
+    suspend fun execute()
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTGlyphHelper.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTGlyphHelper.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import android.net.Uri
+
+/**
+ * A utility for generating glyph ranges and formatting glyph URLs for offline use.
+ */
+internal object MTGlyphHelper {
+    /**
+     * The default maximum Unicode index to cover (Basic Multilingual Plane).
+     */
+    const val DEFAULT_MAX_INDEX = 65535
+
+    /**
+     * Generates the standard 256-step Unicode character ranges.
+     *
+     * @param maxIndex The maximum Unicode index to cover.
+     * @return A list of [MTGlyphRange] objects.
+     */
+    fun generateRanges(maxIndex: Int = DEFAULT_MAX_INDEX): List<MTGlyphRange> {
+        val ranges = mutableListOf<MTGlyphRange>()
+        // Standard Mapbox/MapLibre glyphs are requested in chunks of 256.
+        // Start index is a multiple of 256, end index is start + 255.
+        for (start in 0..maxIndex step 256) {
+            val end = start + 255
+            ranges.add(MTGlyphRange(start, end))
+        }
+        return ranges
+    }
+
+    /**
+     * Formats a glyph URL template with a font stack and a range.
+     *
+     * @param template The glyph URL template.
+     * @param fonts The list of fonts in the font stack.
+     * @param range The glyph range.
+     * @return The formatted URL string.
+     */
+    fun format(
+        template: String,
+        fonts: List<String>,
+        range: MTGlyphRange,
+    ): String {
+        val fontStack = fonts.joinToString(",")
+        return format(template, fontStack, range.toString())
+    }
+
+    /**
+     * Formats a glyph URL template with a font stack string and a range string.
+     *
+     * @param template The glyph URL template.
+     * @param fontStack The font stack string.
+     * @param range The range string.
+     * @return The formatted URL string.
+     */
+    fun format(
+        template: String,
+        fontStack: String,
+        range: String,
+    ): String {
+        val encodedFontStack = Uri.encode(fontStack)
+
+        return template
+            .replace("{fontstack}", encodedFontStack)
+            .replace("{range}", range)
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTGlyphRange.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTGlyphRange.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+/**
+ * Represents a 256-step Unicode character range used for downloading map glyphs.
+ */
+internal data class MTGlyphRange(
+    /**
+     * The start index of the range (inclusive).
+     */
+    val start: Int,
+    /**
+     * The end index of the range (inclusive).
+     */
+    val end: Int,
+) {
+    /**
+     * A string representation of the range in the format "start-end" (e.g., "0-255").
+     */
+    override fun toString(): String = "$start-$end"
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTLocalPlanner.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTLocalPlanner.kt
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import com.maptiler.maptilersdk.MTConfig
+import com.maptiler.maptilersdk.helpers.JsonConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.URL
+
+/**
+ * A local implementation of the [MTOfflinePlanner] interface.
+ */
+internal class MTLocalPlanner : MTOfflinePlanner {
+    override suspend fun estimate(definition: MTOfflineRegionDefinition): MTTileEstimate {
+        validate(definition)
+
+        val estimator = MTOfflineEstimator()
+        val stats = estimator.estimatePack(definition)
+
+        val globalLimit = MTOfflineConfiguration.effectiveGlobalLimit
+        val packLimit = definition.maxTileCount ?: Int.MAX_VALUE
+        val effectiveLimit = minOf(globalLimit, packLimit)
+
+        if (stats.resourceCount > effectiveLimit) {
+            throw MTOfflineError.ExceedsMaximumTileCount(
+                limit = effectiveLimit,
+                requested = stats.resourceCount,
+            )
+        }
+
+        return MTTileEstimate(stats)
+    }
+
+    override suspend fun generateManifest(definition: MTOfflineRegionDefinition): MTManifest {
+        validate(definition)
+
+        val isFlexible = definition.geometry !is MTOfflineRegionGeometry.BoundingBox
+        val paddingMeters = definition.padding ?: if (isFlexible) 2000.0 else null
+
+        // For non-rectangular geometries, slightly pad the bounding box stored in the manifest.
+        var manifestBbox = definition.geometry.bbox
+        if (paddingMeters != null && paddingMeters > 0 && isFlexible) {
+            manifestBbox = manifestBbox.expanded(paddingMeters)
+        }
+
+        val metadata =
+            MTManifestMetadata(
+                referenceStyle = definition.referenceStyle,
+                styleVariant = definition.styleVariant,
+                bbox = manifestBbox,
+                minZoom = definition.minZoom,
+                maxZoom = definition.maxZoom,
+                pixelRatio = definition.pixelRatio,
+            )
+
+        val apiKey = MTConfig.apiKey
+        val styleUrl =
+            definition.referenceStyle.fetchStyleUrl(definition.styleVariant, apiKey)
+                ?: throw MTOfflineError.InvalidRegion
+
+        val (styleResource, dependencies) = resolveStyle(styleUrl)
+
+        val tileResources =
+            generateTileResources(
+                geometry = definition.geometry,
+                minZoom = definition.minZoom,
+                maxZoom = definition.maxZoom,
+                paddingMeters = paddingMeters,
+                dependencies = dependencies,
+            )
+
+        val glyphResources = generateGlyphResources(dependencies)
+        val spriteResources = generateSpriteResources(dependencies)
+
+        val totalCount = tileResources.size + glyphResources.size + spriteResources.size + 1 // +1 for style
+
+        val globalLimit = MTOfflineConfiguration.effectiveGlobalLimit
+        val packLimit = definition.maxTileCount ?: Int.MAX_VALUE
+        val effectiveLimit = minOf(globalLimit, packLimit)
+
+        if (totalCount > effectiveLimit) {
+            throw MTOfflineError.ExceedsMaximumTileCount(
+                limit = effectiveLimit,
+                requested = totalCount,
+            )
+        }
+
+        val manifest =
+            MTManifest(
+                metadata = metadata,
+                style = styleResource,
+                tiles = tileResources,
+                glyphs = glyphResources,
+                sprites = spriteResources,
+            )
+
+        if (manifest.tiles.isEmpty()) {
+            throw MTOfflineError.InvalidRegion
+        }
+
+        return manifest
+    }
+
+    private fun validate(definition: MTOfflineRegionDefinition) {
+        if (definition.minZoom < 0 || definition.maxZoom > 22 || definition.minZoom > definition.maxZoom) {
+            throw MTOfflineError.InvalidRegion
+        }
+
+        val bbox = definition.geometry.bbox
+        if (bbox.minLat < -85.051129 ||
+            bbox.maxLat > 85.051129 ||
+            bbox.minLon < -180.0 ||
+            bbox.maxLon > 180.0 ||
+            bbox.minLat > bbox.maxLat
+        ) {
+            throw MTOfflineError.InvalidRegion
+        }
+    }
+
+    private suspend fun resolveStyle(url: URL): Pair<MTMapResource, MTStyleDependencies> {
+        val normalizedUrl = MTURLNormalizer.normalize(url.toString())
+
+        val data =
+            withContext(Dispatchers.IO) {
+                val request = okhttp3.Request.Builder().url(normalizedUrl).build()
+                MTOfflineHttpClient.client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) throw MTOfflineError.BadResponse(response.code)
+                    response.body?.string() ?: throw MTOfflineError.DownloadFailed(java.io.IOException("Empty body"))
+                }
+            }
+
+        val resource = MTMapResource(url = url.toString(), destinationPath = "style.json")
+        val parser = MTStyleParser()
+        val dependencies = parser.extractDependencies(data)
+        return Pair(resource, dependencies)
+    }
+
+    private suspend fun generateTileResources(
+        geometry: MTOfflineRegionGeometry,
+        minZoom: Int,
+        maxZoom: Int,
+        paddingMeters: Double?,
+        dependencies: MTStyleDependencies,
+    ): List<MTMapResource> {
+        val resources = mutableListOf<MTMapResource>()
+
+        for (source in dependencies.sources) {
+            val resolved = resolveTemplateUrl(source)
+            val template = resolved.template
+
+            var effMin = maxOf(minZoom, resolved.minZoom)
+            var effMax = minOf(maxZoom, resolved.maxZoom)
+
+            if (minZoom > resolved.maxZoom) {
+                effMin = resolved.maxZoom
+                effMax = resolved.maxZoom
+            }
+
+            if (effMin > effMax) continue
+
+            val ext = detectExtension(template)
+
+            val tiles = mutableSetOf<MTTileIndex>()
+            if (geometry is MTOfflineRegionGeometry.BoundingBox) {
+                val splitBoxes = geometry.bbox.normalizedAndSplit()
+                for (box in splitBoxes) {
+                    for (z in effMin..effMax) {
+                        tiles.addAll(MTTileMath.tiles(MTOfflineRegionGeometry.BoundingBox(box), z, paddingMeters))
+                    }
+                }
+            } else {
+                for (z in effMin..effMax) {
+                    tiles.addAll(MTTileMath.tiles(geometry, z, paddingMeters))
+                }
+            }
+
+            for (tile in tiles) {
+                val z = tile.z
+                val x = tile.x
+                val y = tile.y
+
+                val resolvedY =
+                    if (template.contains("{-y}")) {
+                        MTTileMath.flipYCoordinate(y, z)
+                    } else {
+                        y
+                    }
+
+                val tileUrlStr =
+                    template
+                        .replace("{z}", z.toString())
+                        .replace("{x}", x.toString())
+                        .replace("{y}", resolvedY.toString())
+                        .replace("{-y}", resolvedY.toString())
+
+                val destPath = "tiles/${source.id}/$z/$x/$y.$ext"
+                resources.add(MTMapResource(url = tileUrlStr, destinationPath = destPath))
+            }
+        }
+        return resources
+    }
+
+    private data class TemplateInfo(
+        val template: String,
+        val minZoom: Int,
+        val maxZoom: Int,
+    )
+
+    private suspend fun resolveTemplateUrl(source: MTStyleSource): TemplateInfo {
+        val sourceMin = source.minZoom ?: 0
+        val sourceMax = source.maxZoom ?: 22
+
+        if (!source.tiles.isNullOrEmpty()) {
+            return TemplateInfo(source.tiles.first(), sourceMin, sourceMax)
+        }
+
+        val urlStr = source.url ?: throw MTOfflineError.InvalidRegion
+        val normalizedUrl = MTURLNormalizer.normalize(urlStr)
+
+        val tileJsonData =
+            withContext(Dispatchers.IO) {
+                val request = okhttp3.Request.Builder().url(normalizedUrl).build()
+                MTOfflineHttpClient.client.newCall(request).execute().use { response ->
+                    if (!response.isSuccessful) throw MTOfflineError.BadResponse(response.code)
+                    response.body?.string() ?: throw MTOfflineError.DownloadFailed(java.io.IOException("Empty body"))
+                }
+            }
+
+        val tileJson = JsonConfig.json.decodeFromString<MTTileJSON>(tileJsonData)
+        return TemplateInfo(
+            template = tileJson.preferredTileUrlTemplate ?: throw MTOfflineError.InvalidRegion,
+            minZoom = tileJson.minzoom,
+            maxZoom = tileJson.maxzoom,
+        )
+    }
+
+    private fun detectExtension(template: String): String {
+        val lower = template.lowercase()
+        return when {
+            lower.contains(".png") -> "png"
+            lower.contains(".jpg") || lower.contains(".jpeg") -> "jpg"
+            lower.contains(".webp") -> "webp"
+            else -> "pbf"
+        }
+    }
+
+    private fun generateGlyphResources(dependencies: MTStyleDependencies): List<MTMapResource> {
+        val template = dependencies.glyphsTemplate ?: return emptyList()
+        val fontStacks = dependencies.fontStacks
+        if (fontStacks.isEmpty()) return emptyList()
+
+        val resources = mutableListOf<MTMapResource>()
+        val ranges = MTGlyphHelper.generateRanges()
+
+        for (fontStack in fontStacks) {
+            val fontStackStr = fontStack.joinToString(",")
+            for (range in ranges) {
+                val rangeStr = range.toString()
+                val urlStr = MTGlyphHelper.format(template, fontStackStr, rangeStr)
+                val destPath = "glyphs/$fontStackStr/$rangeStr.pbf"
+                resources.add(MTMapResource(url = urlStr, destinationPath = destPath))
+            }
+        }
+        return resources
+    }
+
+    private fun generateSpriteResources(dependencies: MTStyleDependencies): List<MTMapResource> {
+        val resources = mutableListOf<MTMapResource>()
+        for (sprite in dependencies.sprites) {
+            val baseUrl = sprite.url
+
+            val variants = listOf("", "@2x")
+            val formats = listOf(".json", ".png")
+
+            for (variant in variants) {
+                for (format in formats) {
+                    val url = "$baseUrl$variant$format"
+                    val filename =
+                        if (sprite.id == "default") {
+                            "sprite$variant$format"
+                        } else {
+                            "sprite-${sprite.id}$variant$format"
+                        }
+                    resources.add(MTMapResource(url = url, destinationPath = filename))
+                }
+            }
+        }
+        return resources
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineDownloader.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineDownloader.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import android.content.Context
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * An actor-like class responsible for managing offline downloads.
+ */
+internal class MTOfflineDownloader(
+    private val context: Context,
+    private val maxInFlight: Int = 5,
+) {
+    @Volatile
+    private var isPackCancelled: Boolean = false
+
+    /**
+     * Downloads the specified tasks.
+     *
+     * @param tasks The list of tasks to execute.
+     * @param packId The ID of the offline pack.
+     * @param progressHandler A callback for progress updates (completed, skipped).
+     */
+    suspend fun download(
+        tasks: List<MTDownloadTask>,
+        packId: String,
+        progressHandler: ((completed: Int, skipped: Int) -> Unit)? = null,
+    ) = withContext(Dispatchers.IO) {
+        isPackCancelled = false
+
+        MTOfflineStorage.cleanStaleTempFiles(context, packId)
+
+        val (pendingTasks, skippedCount) = filterPendingTasks(tasks)
+        progressHandler?.invoke(0, skippedCount)
+
+        if (pendingTasks.isEmpty()) return@withContext
+
+        // Producer-consumer using Channel
+        val channel = Channel<MTDownloadTask>(capacity = Channel.BUFFERED)
+
+        try {
+            coroutineScope {
+                // Start workers (consumers)
+                val workers =
+                    List(maxInFlight) {
+                        launch {
+                            for (task in channel) {
+                                if (isPackCancelled) break
+                                try {
+                                    task.execute()
+                                    if (!isPackCancelled) {
+                                        progressHandler?.invoke(1, 0)
+                                    }
+                                } catch (e: Exception) {
+                                    if (e !is CancellationException) {
+                                        // Propagate the error up to fail the coroutineScope
+                                        throw e
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                // Producer
+                launch {
+                    for (task in pendingTasks) {
+                        if (isPackCancelled) break
+                        channel.send(task)
+                    }
+                    channel.close() // Signal workers that no more tasks are coming
+                }
+            }
+        } catch (e: Exception) {
+            if (isPackCancelled || e is CancellationException) {
+                throw CancellationException("Download cancelled")
+            }
+            throw e
+        }
+    }
+
+    private fun filterPendingTasks(tasks: List<MTDownloadTask>): Pair<List<MTDownloadTask>, Int> {
+        val pendingTasks = mutableListOf<MTDownloadTask>()
+        var skippedCount = 0
+
+        for (task in tasks) {
+            val destFile = task.destinationFile
+            if (destFile != null && MTOfflineStorage.isFileVerified(destFile)) {
+                skippedCount++
+            } else {
+                pendingTasks.add(task)
+            }
+        }
+
+        return Pair(pendingTasks, skippedCount)
+    }
+
+    /**
+     * Cancels the ongoing download process.
+     */
+    fun cancel() {
+        isPackCancelled = true
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineError.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineError.kt
@@ -55,4 +55,27 @@ public sealed class MTOfflineError : Exception() {
      * A download operation failed.
      */
     public data class DownloadFailed(override val cause: Throwable) : MTOfflineError()
+
+    /**
+     * The requested region exceeds the maximum allowed resource count.
+     */
+    public data class ExceedsMaximumTileCount(val limit: Int, val requested: Int) : MTOfflineError() {
+        override val message: String
+            get() = "The requested region exceeds the maximum allowed resource count (Limit: $limit, Requested: $requested)"
+    }
+
+    /**
+     * The server returned a bad response code.
+     */
+    public data class BadResponse(val statusCode: Int) : MTOfflineError()
+
+    /**
+     * A network error occurred.
+     */
+    public data class NetworkError(override val cause: Throwable) : MTOfflineError()
+
+    /**
+     * The downloaded content type does not match the expected type.
+     */
+    public data class ContentMismatch(val expected: String, val actual: String) : MTOfflineError()
 }

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineEstimator.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineEstimator.kt
@@ -129,7 +129,11 @@ class MTOfflineEstimator {
 
     private suspend fun fetchString(url: URL): String =
         withContext(Dispatchers.IO) {
-            url.readText()
+            val request = okhttp3.Request.Builder().url(url.toString()).build()
+            MTOfflineHttpClient.client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) throw Exception("Bad response: ${response.code}")
+                response.body?.string() ?: throw Exception("Empty body")
+            }
         }
 
     private data class TemplateInfo(

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineHttpClient.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineHttpClient.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import com.maptiler.maptilersdk.MTConfig
+import okhttp3.ConnectionPool
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Response
+import java.util.concurrent.TimeUnit
+
+/**
+ * Shared OkHttp client specifically configured for offline map downloads.
+ */
+internal object MTOfflineHttpClient {
+    /**
+     * Interceptor to add the custom User-Agent to all requests.
+     */
+    private class UserAgentInterceptor : Interceptor {
+        override fun intercept(chain: Interceptor.Chain): Response {
+            val originalRequest = chain.request()
+            val requestWithUserAgent =
+                originalRequest.newBuilder()
+                    .header("User-Agent", MTConfig.CUSTOM_USER_AGENT)
+                    .build()
+            return chain.proceed(requestWithUserAgent)
+        }
+    }
+
+    /**
+     * The configured OkHttpClient instance for offline downloads.
+     * Features optimized connection pooling for many small files and appropriate timeouts.
+     */
+    val client: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .connectionPool(ConnectionPool(10, 5, TimeUnit.MINUTES))
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
+            .addInterceptor(UserAgentInterceptor())
+            .build()
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflinePlanner.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflinePlanner.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+/**
+ * Interface defining the core interface for planning an offline download.
+ */
+internal interface MTOfflinePlanner {
+    /**
+     * Estimates the size and resources required for an offline region.
+     *
+     * @param definition The region definition to estimate.
+     * @return An [MTTileEstimate] containing the results.
+     */
+    suspend fun estimate(definition: MTOfflineRegionDefinition): MTTileEstimate
+
+    /**
+     * Generates a manifest detailing all resources required for an offline region.
+     *
+     * @param definition The region definition to generate a manifest for.
+     * @return An [MTManifest] containing the required resources.
+     */
+    suspend fun generateManifest(definition: MTOfflineRegionDefinition): MTManifest
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflinePlannerFactory.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflinePlannerFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+/**
+ * Factory for creating [MTOfflinePlanner] instances.
+ */
+internal object MTOfflinePlannerFactory {
+    /**
+     * Creates an [MTOfflinePlanner] based on the current configuration.
+     *
+     * @return A new [MTOfflinePlanner] instance.
+     */
+    fun createPlanner(): MTOfflinePlanner {
+        return when (MTOfflineConfiguration.plannerType) {
+            MTOfflinePlannerType.LOCAL -> MTLocalPlanner()
+            MTOfflinePlannerType.SERVER -> {
+                // Fallback to local if server planner is not yet implemented or available
+                MTLocalPlanner()
+            }
+        }
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineStorage.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTOfflineStorage.kt
@@ -151,6 +151,10 @@ internal object MTOfflineStorage {
             calculateDirectorySize(packDir)
         }
 
+    fun isFileVerified(file: File): Boolean {
+        return file.exists() && file.length() > 0
+    }
+
     suspend fun isFileVerified(
         context: Context,
         packId: String,
@@ -158,7 +162,7 @@ internal object MTOfflineStorage {
     ): Boolean =
         withContext(Dispatchers.IO) {
             val file = MTOfflineStoragePaths.getAbsoluteFile(context, packId, relativePath)
-            file.exists() && file.length() > 0
+            isFileVerified(file)
         }
 
     /**
@@ -216,6 +220,11 @@ internal object MTOfflineStorage {
             }
         }
     }
+
+    suspend fun write(
+        data: ByteArray,
+        file: File,
+    ) = writeAtomic(file, data)
 
     // MARK: - Private Helpers
 

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTResourceDownloadTask.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTResourceDownloadTask.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+
+/**
+ * A concrete download task that fetches a single map resource.
+ */
+internal class MTResourceDownloadTask(
+    private val context: Context,
+    val resource: MTMapResource,
+    val packId: String,
+) : MTDownloadTask {
+    override val id: String = resource.url
+
+    override val destinationFile: File?
+        get() = MTOfflineStoragePaths.getAbsoluteFile(context, packId, resource.destinationPath)
+
+    override suspend fun execute() {
+        val maxAttempts = 3
+        var currentAttempt = 0
+        var lastError: Exception? = null
+
+        while (currentAttempt < maxAttempts) {
+            try {
+                performDownload()
+                return // Success
+            } catch (e: Exception) {
+                currentAttempt++
+                lastError = e
+                if (currentAttempt < maxAttempts) {
+                    delay(1000L * currentAttempt)
+                }
+            }
+        }
+
+        throw lastError ?: MTOfflineError.DownloadFailed(Exception("Unknown error"))
+    }
+
+    private suspend fun performDownload() =
+        withContext(Dispatchers.IO) {
+            val normalizedUrl = MTURLNormalizer.normalize(resource.url)
+
+            val request =
+                Request.Builder()
+                    .url(normalizedUrl)
+                    .build()
+
+            MTOfflineHttpClient.client.newCall(request).execute().use { response ->
+                val statusCode = response.code
+                when (statusCode) {
+                    204 -> return@withContext
+                    in 200..299 -> {
+                        val contentType = response.header("Content-Type")
+                        validateContentType(contentType, resource.url)
+
+                        val body = response.body ?: throw MTOfflineError.DownloadFailed(IOException("Empty response body"))
+                        val data = body.bytes()
+
+                        val destFile = destinationFile ?: return@withContext
+                        MTOfflineStorage.write(data, destFile)
+                    }
+                    else -> throw MTOfflineError.BadResponse(statusCode)
+                }
+            }
+        }
+
+    private fun validateContentType(
+        contentType: String?,
+        resourceURL: String,
+    ) {
+        if (contentType == null) return
+
+        val urlPath = resourceURL.lowercase()
+        if (urlPath.endsWith(".pbf") || urlPath.endsWith(".mvt")) {
+            if (contentType.contains("text/html")) {
+                throw MTOfflineError.ContentMismatch(
+                    expected = "application/x-protobuf",
+                    actual = contentType,
+                )
+            }
+        } else if (urlPath.endsWith(".png") || urlPath.endsWith(".jpg") || urlPath.endsWith(".jpeg") || urlPath.endsWith(".webp")) {
+            if (contentType.contains("text/html") || contentType.contains("application/json")) {
+                throw MTOfflineError.ContentMismatch(
+                    expected = "image/*",
+                    actual = contentType,
+                )
+            }
+        }
+    }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTStyleDownloadTask.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTStyleDownloadTask.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+import okhttp3.Request
+import java.io.File
+import java.io.IOException
+
+/**
+ * A concrete download task that fetches the map style.
+ */
+internal class MTStyleDownloadTask(
+    private val context: Context,
+    val resource: MTMapResource,
+    val packId: String,
+) : MTDownloadTask {
+    override val id: String = resource.url
+
+    override val destinationFile: File?
+        get() = MTOfflineStoragePaths.getAbsoluteFile(context, packId, resource.destinationPath)
+
+    override suspend fun execute() {
+        val maxAttempts = 3
+        var currentAttempt = 0
+        var lastError: Exception? = null
+
+        while (currentAttempt < maxAttempts) {
+            try {
+                performDownload()
+                return // Success
+            } catch (e: Exception) {
+                currentAttempt++
+                lastError = e
+                if (currentAttempt < maxAttempts) {
+                    delay(1000L * currentAttempt)
+                }
+            }
+        }
+
+        throw lastError ?: MTOfflineError.DownloadFailed(Exception("Unknown error"))
+    }
+
+    private suspend fun performDownload() =
+        withContext(Dispatchers.IO) {
+            val normalizedUrl = MTURLNormalizer.normalize(resource.url)
+
+            val request =
+                Request.Builder()
+                    .url(normalizedUrl)
+                    .build()
+
+            MTOfflineHttpClient.client.newCall(request).execute().use { response ->
+                val statusCode = response.code
+                when (statusCode) {
+                    204 -> return@withContext
+                    in 200..299 -> {
+                        val body = response.body ?: throw MTOfflineError.DownloadFailed(IOException("Empty response body"))
+                        val data = body.bytes()
+
+                        val destFile = destinationFile ?: return@withContext
+                        MTOfflineStorage.write(data, destFile)
+                    }
+                    else -> throw MTOfflineError.BadResponse(statusCode)
+                }
+            }
+        }
+}

--- a/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTTileEstimate.kt
+++ b/MapTilerSDK/src/main/java/com/maptiler/maptilersdk/offline/MTTileEstimate.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026, MapTiler
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ */
+
+package com.maptiler.maptilersdk.offline
+
+/**
+ * Represents the estimated size and resource count for an offline region.
+ */
+internal data class MTTileEstimate(
+    /**
+     * The detailed pack statistics.
+     */
+    val stats: MTPackStats,
+)


### PR DESCRIPTION
RD-2066
+
RD-2067
+
RD-2068

## Objective
Add offline planner

## Description
Added MTLocalPlanner, glyph helper and download tasks (with concurrent downloading)

## Acceptance
Linted and tests.
